### PR TITLE
Updated to use built in Homebrew Versioning

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,3 @@
-default['sprout']['elasticsearch']['version']['short'] = '14'
-default['sprout']['elasticsearch']['version']['long'] = '1.4'
+default['sprout']['elasticsearch']['version']['short'] = '17'
+default['sprout']['elasticsearch']['version']['long'] = '1.7'
 default['sprout']['elasticsearch']['plist_filename'] = "homebrew.mxcl.elasticsearch#{node['sprout']['elasticsearch']['version']['short']}.plist"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'danielj@foreflight.com'
 license          'MIT'
 description      'Recipes to install and configure ElasticSearch on OS X'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'
 
 supports         'mac_os_x'
 depends          'homebrew', '>= 1.5.4'

--- a/recipes/install_elasticsearch.rb
+++ b/recipes/install_elasticsearch.rb
@@ -1,5 +1,4 @@
 include_recipe 'homebrew'
 include_recipe 'java'
 
-homebrew_tap 'homebrew/versions'
-homebrew_package "elasticsearch#{node['sprout']['elasticsearch']['version']['short']}"
+homebrew_package "elasticsearch@#{node['sprout']['elasticsearch']['version']['long']}"


### PR DESCRIPTION
This updates the package to use the built in homebrew versioning now in core http://docs.brew.sh/Versions.html . It is no longer necessary to tap the `homebrew/versions` keg. This also changes the syntax from `elasticsearch17` to `elasticsearch@1.7` .

I'm not sure how to actually test this, so pointers would be appreciated. 